### PR TITLE
Stop using a matrix section in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,14 @@ julia:
   - 1
   - nightly
 
-matrix:
-  allow_failures:
-    - julia: nightly
-
 after_success:
   - julia --project=coverage/ -e 'using Pkg; Pkg.instantiate()'
   - julia --project=coverage/ coverage/coverage.jl
 
 jobs:
+  allow_failures:
+    - julia: nightly
+
   include:
     - stage: "Deploy docs"
       julia: 1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 
 os:
   - linux
-  - osx
+  # - osx
 
 julia:
   - 1.0
@@ -19,7 +19,7 @@ jobs:
 
   include:
     - stage: "Deploy docs"
-      julia: 1.0
+      julia: 1
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MatrixDepot = "b51810bb-c9f3-55da-ae3c-350fc1fbce05"
 
 [compat]
-Documenter = "~0.19"
+Documenter = "0.25"
+MatrixDepot = "0.8"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,9 @@
-if Base.HOME_PROJECT[] !== nothing
-    # JuliaLang/julia/pull/28625
-    Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[])
-end
+push!(LOAD_PATH,"../src/")
 
 using Documenter, TSVD
 
-makedocs()
+makedocs(sitename="TSVD Documentation")
 
 deploydocs(
-    deps   = Deps.pip("mkdocs==0.17.5", "python-markdown-math", "mkdocs-material==2.9.4"),
     repo = "github.com/andreasnoack/TSVD.jl.git",
-    julia  = "1.0"
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ CurrentModule = TSVD
 DocTestSetup = quote
     using MatrixDepot, TSVD
     try
-        matrixdepot("LPnetlib/lp_osa_30", :get)
+        matrixdepot("LPnetlib/lp_osa_30")
     catch
     	nothing
     end

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -313,7 +313,7 @@ The output of the procesure it the truple tuple `(U, s, V)`
 # Examples
 
 ```jldoctest
-julia> A = matrixdepot("LPnetlib/lp_osa_30", :r)
+julia> A = matrixdepot("LPnetlib/lp_osa_30")
 4350×104374 SparseArrays.SparseMatrixCSC{Float64,Int64} with 604488 stored entries:
   [1     ,      1]  =  1.0
   [2     ,      2]  =  1.0


### PR DESCRIPTION
It has been deprecated and was overwriting the docs generation job